### PR TITLE
chore: Add db access instance

### DIFF
--- a/Modules/EC2/main.tf
+++ b/Modules/EC2/main.tf
@@ -1,0 +1,29 @@
+data "aws_ami" "amazon_linux" {
+  most_recent = true
+  owners      = ["amazon"]
+
+  filter {
+    name   = "name"
+    values = ["amzn2-ami-hvm-*-x86_64-gp2"]
+  }
+}
+
+resource "aws_instance" "db_access_instance" {
+  ami                    = data.aws_ami.amazon_linux.id
+  instance_type          = "t2.micro"
+  subnet_id              = var.public_subnets[0]
+  vpc_security_group_ids = [var.sg_db_access_instance_id]
+
+  instance_market_options {
+    market_type = "spot"
+    spot_options {
+      spot_instance_type = "one-time"
+    }
+  }
+
+  associate_public_ip_address = true
+
+  tags = {
+    Name = "dummy-db-access-instance"
+  }
+}

--- a/Modules/EC2/variables.tf
+++ b/Modules/EC2/variables.tf
@@ -1,0 +1,7 @@
+variable "public_subnets" {
+  type = list(string)
+}
+
+variable "sg_db_access_instance_id" {
+  type = string
+}

--- a/Modules/SecurityGroup/main.tf
+++ b/Modules/SecurityGroup/main.tf
@@ -94,7 +94,7 @@ resource "aws_security_group" "sg_mysql" {
     from_port       = 3306
     to_port         = 3306
     protocol        = "tcp"
-    security_groups = [aws_security_group.sg_ecs.id]
+    security_groups = [aws_security_group.sg_ecs.id, aws_security_group.sg_db_access_instance.id]
   }
 
   egress {
@@ -117,7 +117,7 @@ resource "aws_security_group" "sg_valkey" {
     from_port       = 6379
     to_port         = 6379
     protocol        = "tcp"
-    security_groups = [aws_security_group.sg_ecs.id]
+    security_groups = [aws_security_group.sg_ecs.id, aws_security_group.sg_db_access_instance.id]
   }
 
   egress {
@@ -140,7 +140,7 @@ resource "aws_security_group" "sg_mongodb" {
     from_port       = 27017
     to_port         = 27017
     protocol        = "tcp"
-    security_groups = [aws_security_group.sg_ecs.id]
+    security_groups = [aws_security_group.sg_ecs.id, aws_security_group.sg_db_access_instance.id]
   }
 
   egress {
@@ -152,5 +152,24 @@ resource "aws_security_group" "sg_mongodb" {
 
   tags = {
     Name = "dutymate-sg-mongodb"
+  }
+}
+
+resource "aws_security_group" "sg_db_access_instance" {
+  name   = "dutymate-sg-db-access-instance"
+  vpc_id = var.vpc_id
+
+  ingress {
+    from_port   = 22
+    to_port     = 22
+    protocol    = "tcp"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  egress {
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
   }
 }

--- a/Modules/SecurityGroup/outputs.tf
+++ b/Modules/SecurityGroup/outputs.tf
@@ -2,6 +2,10 @@ output "sg_alb_id" {
   value = aws_security_group.sg_alb.id
 }
 
+output "sg_db_access_instance_id" {
+  value = aws_security_group.sg_db_access_instance.id
+}
+
 output "sg_ecs_id" {
   value = aws_security_group.sg_ecs.id
 }

--- a/main.tf
+++ b/main.tf
@@ -52,6 +52,12 @@ module "ecs" {
   sg_ecs_id                   = module.security_group.sg_ecs_id
 }
 
+module "ec2" {
+  source                   = "./Modules/EC2"
+  public_subnets           = module.networking.public_subnets
+  sg_db_access_instance_id = module.security_group.sg_db_access_instance_id
+}
+
 module "elasticache" {
   source         = "./Modules/ElastiCache"
   public_subnets = module.networking.public_subnets


### PR DESCRIPTION
This pull request introduces a new EC2 module to provision a spot instance for database access and updates the security group configurations to support this instance. The changes include defining the necessary resources, variables, and outputs, as well as integrating the new module into the main infrastructure configuration.

### EC2 Module Implementation:
* Added a new `aws_instance` resource in `Modules/EC2/main.tf` to create a spot instance using the latest Amazon Linux 2 AMI. This instance is tagged as `dummy-db-access-instance` and is associated with a public IP. (`[Modules/EC2/main.tfR1-R29](diffhunk://#diff-55692756cb1a298134c71fccdd03f55f2eed57b252432187ba7dc59e88aaa580R1-R29)`)
* Defined new variables `public_subnets` and `sg_db_access_instance_id` in `Modules/EC2/variables.tf` to parameterize the subnet and security group for the instance. (`[Modules/EC2/variables.tfR1-R7](diffhunk://#diff-12f99cff164434fad4c8bd4ff5cb61328cf5231842fc4fbaff4475415c76b3f6R1-R7)`)

### Security Group Updates:
* Added a new security group `sg_db_access_instance` in `Modules/SecurityGroup/main.tf` to allow SSH ingress from any IP and unrestricted egress. (`[Modules/SecurityGroup/main.tfR157-R175](diffhunk://#diff-29818b55ae9cc398e9749b8de85a02e76cee370b675117076252b8ab335a6bb3R157-R175)`)
* Updated existing security groups (`sg_mysql`, `sg_valkey`, `sg_mongodb`) to include `sg_db_access_instance` for secure communication with the new instance. (`[[1]](diffhunk://#diff-29818b55ae9cc398e9749b8de85a02e76cee370b675117076252b8ab335a6bb3L97-R97)`, `[[2]](diffhunk://#diff-29818b55ae9cc398e9749b8de85a02e76cee370b675117076252b8ab335a6bb3L120-R120)`, `[[3]](diffhunk://#diff-29818b55ae9cc398e9749b8de85a02e76cee370b675117076252b8ab335a6bb3L143-R143)`)

### Outputs and Integration:
* Added an output `sg_db_access_instance_id` in `Modules/SecurityGroup/outputs.tf` to expose the new security group ID. (`[Modules/SecurityGroup/outputs.tfR5-R8](diffhunk://#diff-20aa32128be1843d003a3b4ffad1da7c7c12a6b6bbd2e438f4ee21284c39eb7eR5-R8)`)
* Integrated the new EC2 module into the main `main.tf` file, passing the required subnet and security group as inputs. (`[main.tfR55-R60](diffhunk://#diff-dc46acf24afd63ef8c556b77c126ccc6e578bc87e3aa09a931f33d9bf2532fbbR55-R60)`)