### PR TITLE
fix: Add amazon provided dns to ecs instances

### DIFF
--- a/Modules/Networking/main.tf
+++ b/Modules/Networking/main.tf
@@ -55,3 +55,17 @@ resource "aws_route_table_association" "public_route_table_assoc" {
   subnet_id      = aws_subnet.public_subnets[count.index].id
   route_table_id = aws_route_table.public_route_table.id
 }
+
+resource "aws_vpc_dhcp_options" "dhcp_options" {
+  domain_name         = "ec2.internal"
+  domain_name_servers = ["AmazonProvidedDNS"]
+
+  tags = {
+    Name = "dutymate-dhcp-options"
+  }
+}
+
+resource "aws_vpc_dhcp_options_association" "dhcp_options_assoc" {
+  vpc_id          = aws_vpc.vpc.id
+  dhcp_options_id = aws_vpc_dhcp_options.dhcp_options.id
+}


### PR DESCRIPTION
This pull request introduces new resources to configure DHCP options for the VPC in the `Modules/Networking/main.tf` file. These changes enhance the VPC's DNS and domain name configuration.

### Added DHCP Options Configuration:

* **`aws_vpc_dhcp_options` Resource**: Configures DHCP options for the VPC, including setting the domain name to `ec2.internal` and using `AmazonProvidedDNS` as the domain name servers. Tags the resource with the name `dutymate-dhcp-options`.
* **`aws_vpc_dhcp_options_association` Resource**: Associates the newly created DHCP options with the existing VPC.