### PR TITLE
chore: Set maximum retry attempts to 1

### DIFF
--- a/Modules/EventBridge/main.tf
+++ b/Modules/EventBridge/main.tf
@@ -59,4 +59,9 @@ resource "aws_cloudwatch_event_target" "api_targets" {
   rule     = aws_cloudwatch_event_rule.api_rules[each.key].name
   arn      = aws_cloudwatch_event_api_destination.api_destinations[each.key].arn
   role_arn = var.eventbridge_api_destinations_role_arn
+
+  retry_policy {
+    maximum_event_age_in_seconds = 60
+    maximum_retry_attempts       = 1
+  }
 }


### PR DESCRIPTION
This pull request introduces a change to the `Modules/EventBridge/main.tf` file to enhance the reliability of API destinations by adding a retry policy to the `aws_cloudwatch_event_target` resource.

**Enhancements to reliability:**

* [`Modules/EventBridge/main.tf`](diffhunk://#diff-c5a9745c638137e44bdad31d702e0cc3642b695e4089600655d7761844b0125aR62-R66): Added a `retry_policy` block to the `aws_cloudwatch_event_target` resource, specifying `maximum_event_age_in_seconds` as 60 and `maximum_retry_attempts` as 1. This ensures failed events are retried within a short time frame, improving system robustness.