### PR TITLE
fix: Correct typo in ec2 module

### DIFF
--- a/Modules/EC2/main.tf
+++ b/Modules/EC2/main.tf
@@ -24,6 +24,6 @@ resource "aws_instance" "db_access_instance" {
   associate_public_ip_address = true
 
   tags = {
-    Name = "dummy-db-access-instance"
+    Name = "dutymate-db-access-instance"
   }
 }


### PR DESCRIPTION
This pull request includes a small change to the `Modules/EC2/main.tf` file. The change updates the `Name` tag for the `aws_instance` resource to reflect a more meaningful identifier.

* [`Modules/EC2/main.tf`](diffhunk://#diff-55692756cb1a298134c71fccdd03f55f2eed57b252432187ba7dc59e88aaa580L27-R27): Updated the `Name` tag in the `aws_instance` resource from `"dummy-db-access-instance"` to `"dutymate-db-access-instance"` to provide a clearer and more relevant naming convention.