### PR TITLE
chore: Add DeleteObject action to asset bucket policy

### DIFF
--- a/Modules/S3/main.tf
+++ b/Modules/S3/main.tf
@@ -55,11 +55,12 @@ resource "aws_s3_bucket_policy" "asset_bucket_policy" {
     Version = "2012-10-17"
     Statement = [
       {
-        Sid       = "AllowWriteAccess"
+        Sid       = "AllowPutAndDeleteAccess"
         Effect    = "Allow"
         Principal = "*"
         Action = [
-          "s3:PutObject"
+          "s3:PutObject",
+          "s3:DeleteObject",
         ]
         Resource = "${aws_s3_bucket.asset_bucket.arn}/*"
       },


### PR DESCRIPTION
This pull request includes a modification to the `aws_s3_bucket_policy` resource in `Modules/S3/main.tf`. The change updates the policy to expand the allowed actions for the bucket.

Policy update:

* [`Modules/S3/main.tf`](diffhunk://#diff-9135e5eabceddf9b491bb5c896b26d7e5f2b5f0ab233a800204c38ca969ed968L58-R63): Changed the `Sid` value from `AllowWriteAccess` to `AllowPutAndDeleteAccess` and added `s3:DeleteObject` to the list of allowed actions, alongside `s3:PutObject`. This expands the permissions to include object deletion.