### PR TITLE
chore: Add Sid to S3 bucket policy for clearer statement identification

### DIFF
--- a/Modules/S3/main.tf
+++ b/Modules/S3/main.tf
@@ -88,6 +88,7 @@ resource "aws_s3_bucket_policy" "frontend_bucket_policy" {
     Version = "2012-10-17"
     Statement = [
       {
+        Sid       = "AllowCloudFrontServiceReadAccess"
         Effect    = "Allow"
         Principal = { Service = "cloudfront.amazonaws.com" }
         Action    = "s3:GetObject"


### PR DESCRIPTION
This pull request includes a small change to the `Modules/S3/main.tf` file. The change adds a `Sid` field to the `aws_s3_bucket_policy` resource to specify the statement identifier for allowing CloudFront service read access.