### PR TITLE
chore: Improve ECS service stability under Spot interruptions

### DIFF
--- a/Modules/AWS/ALB/main.tf
+++ b/Modules/AWS/ALB/main.tf
@@ -18,7 +18,7 @@ resource "aws_alb_target_group" "alb_target_group" {
   protocol             = "HTTP"
   vpc_id               = var.vpc_id
   target_type          = "instance"
-  deregistration_delay = 5
+  deregistration_delay = 30
 
   health_check {
     path                = var.alb_health_check_path

--- a/Modules/AWS/ECS/main.tf
+++ b/Modules/AWS/ECS/main.tf
@@ -60,6 +60,16 @@ resource "aws_ecs_service" "ecs_service" {
   deployment_minimum_healthy_percent = 50
   deployment_maximum_percent         = 100
 
+  capacity_provider_strategy {
+    capacity_provider = aws_ecs_capacity_provider.capacity_provider.name
+    base              = 2
+    weight            = 1
+  }
+
+  placement_constraints {
+    type = "distinctInstance"
+  }
+
   load_balancer {
     target_group_arn = var.alb_target_group_arn
     container_port   = 8080

--- a/Modules/AWS/ECS/main.tf
+++ b/Modules/AWS/ECS/main.tf
@@ -154,10 +154,10 @@ resource "aws_ecs_capacity_provider" "capacity_provider" {
     managed_termination_protection = "ENABLED"
 
     managed_scaling {
+      status                    = "ENABLED"
+      target_capacity           = 90
       maximum_scaling_step_size = 5
       minimum_scaling_step_size = 1
-      status                    = "ENABLED"
-      target_capacity           = 100
     }
   }
 

--- a/Modules/AWS/ECS/main.tf
+++ b/Modules/AWS/ECS/main.tf
@@ -19,11 +19,12 @@ resource "aws_ecs_task_definition" "ecs_task_definition" {
 
   container_definitions = jsonencode([
     {
-      name      = "dutymate-container",
-      image     = "${var.ecr_repository_url}:latest",
-      memory    = 768,
-      cpu       = 512,
-      essential = true,
+      name              = "dutymate-container",
+      image             = "${var.ecr_repository_url}:latest",
+      cpu               = 512,
+      memoryReservation = 512,
+      memory            = 768,
+      essential         = true,
       portMappings = [{
         containerPort = 8080,
         hostPort      = 8080,


### PR DESCRIPTION
This pull request introduces several improvements to the AWS ECS and ALB infrastructure modules. The main changes focus on optimizing ECS resource allocation, enhancing scaling strategies, and adjusting ALB target group settings for better performance and reliability.

**ECS Service & Capacity Provider Enhancements:**

* Added a `capacity_provider_strategy` block to the ECS service, specifying the use of the defined capacity provider with a base of 2 and weight of 1 to better control resource allocation.
* Enabled managed scaling in the ECS capacity provider and set the target capacity to 90% (down from 100%) for more efficient scaling.
* Introduced a `placement_constraints` block to ensure containers are placed on distinct instances, improving fault tolerance.

**ECS Task Definition Improvements:**

* Changed memory configuration in the ECS task definition by adding `memoryReservation` (512) alongside `memory` (768) for better resource management within the container.

**ALB Target Group Configuration:**

* Increased the `deregistration_delay` for the ALB target group from 5 seconds to 30 seconds to allow more time for in-flight requests to complete during instance deregistration.