### PR TITLE
misc: Align resource naming and tags

### DIFF
--- a/Modules/AWS/ECS/main.tf
+++ b/Modules/AWS/ECS/main.tf
@@ -166,7 +166,7 @@ resource "aws_ecs_capacity_provider" "capacity_provider" {
   }
 }
 
-resource "aws_ecs_cluster_capacity_providers" "capacity_provider_association" {
+resource "aws_ecs_cluster_capacity_providers" "capacity_provider_assoc" {
   cluster_name       = aws_ecs_cluster.ecs_cluster.name
   capacity_providers = [aws_ecs_capacity_provider.capacity_provider.name]
 }

--- a/Modules/AWS/SecurityGroup/main.tf
+++ b/Modules/AWS/SecurityGroup/main.tf
@@ -172,4 +172,8 @@ resource "aws_security_group" "sg_db_access_instance" {
     protocol    = "-1"
     cidr_blocks = ["0.0.0.0/0"]
   }
+
+  tags = {
+    Name = "dutymate-sg-db-access-instance"
+  }
 }


### PR DESCRIPTION
This pull request introduces minor improvements to the AWS Terraform configuration, focusing on resource naming consistency and better resource tagging.

Resource naming and tagging updates:

* Renamed the `aws_ecs_cluster_capacity_providers` resource from `capacity_provider_association` to `capacity_provider_assoc` in `Modules/AWS/ECS/main.tf` for consistency with naming conventions.
* Added a `Name` tag to the `aws_security_group.sg_db_access_instance` resource in `Modules/AWS/SecurityGroup/main.tf` to improve resource identification.