### PR TITLE
chore: Set container memory reservation to 640m

### DIFF
--- a/Modules/AWS/ECS/main.tf
+++ b/Modules/AWS/ECS/main.tf
@@ -22,7 +22,7 @@ resource "aws_ecs_task_definition" "ecs_task_definition" {
       name              = "dutymate-container",
       image             = "${var.ecr_repository_url}:latest",
       cpu               = 512,
-      memoryReservation = 512,
+      memoryReservation = 640,
       memory            = 768,
       essential         = true,
       portMappings = [{


### PR DESCRIPTION
This pull request makes a minor adjustment to the ECS task definition by increasing the `memoryReservation` for the `dutymate-container` to ensure better baseline memory availability.

* Increased `memoryReservation` from 512 to 640 in the `aws_ecs_task_definition` resource for the `dutymate-container` (`Modules/AWS/ECS/main.tf`).